### PR TITLE
Fix typo

### DIFF
--- a/src/components/Level/Level.js
+++ b/src/components/Level/Level.js
@@ -288,7 +288,7 @@ export default function Level(props) {
         <div className={styles.bottomRightPanel}>
           {anyNerfed ? (
             <>
-              Nice thinking. Unfortuantely for you,{" "}
+              Nice thinking. Unfortunately for you,{" "}
               {FORMATTED_NERFED_PROPERTY_NAMES} are forbidden.
             </>
           ) : (


### PR DESCRIPTION
Fixes a typo in the error message when using forbidden CSS properties.